### PR TITLE
feat: transform hmset object arguments into key values

### DIFF
--- a/__tests__/test-case.js
+++ b/__tests__/test-case.js
@@ -218,6 +218,20 @@ module.exports = function (cacheClient, cacheType) {
         expect(await cacheClient.hgetall('hash')).toEqual({v1: '1', v2: '2', v3: '3'})
         expect(await cacheClient.hgetall('xxxx')).toEqual({})
       })
+
+      it('hmset key', async () => {
+        expect(await cacheClient.hgetall('hash')).toEqual({})
+
+        await cacheClient.hmset('hash', 'v1', 1, 'v2', 2, 'v3', 3)
+        expect(await cacheClient.hgetall('hash')).toEqual({v1: '1', v2: '2', v3: '3'})
+      })
+
+      it('hmset key object', async () => {
+        expect(await cacheClient.hgetall('hash')).toEqual({})
+
+        await cacheClient.hmset('hash', {v1: 1, v2: 2, v3: 3})
+        expect(await cacheClient.hgetall('hash')).toEqual({v1: '1', v2: '2', v3: '3'})
+      })
     })
   })
 }

--- a/index.js
+++ b/index.js
@@ -15,6 +15,18 @@ module.exports = function (jcachePath) {
       const cmd = new jcache.RCommand()
       cmd.Arg(0, command)
 
+      
+      if (command === 'hmset') {
+        if (argvs.length === 2) {
+          if (typeof argvs[1] === 'object') {
+            let obj = argvs.pop()
+            for (var key in obj) {
+              argvs.push(key, obj[key])
+            }
+          }
+        }
+      }
+
       argvs.forEach((argv, i) => cmd.Arg(i + 1, argv))
       indexes.forEach(index => cmd.Key(index + 1))
 


### PR DESCRIPTION
converting
```
hmset('key', { k1: 'v1', k2: 'v2' })
```

into

```
hmset('key', 'k1', 'v1', 'k2', 'v2')
```